### PR TITLE
Do not create an index when options.unique=false

### DIFF
--- a/index.js
+++ b/index.js
@@ -65,7 +65,7 @@ exports.plugin = function (schema, options) {
     type: Number,
     require: true
   };
-  if (settings.field !== '_id')
+  if (settings.field !== '_id' && settings.unique)
     fields[settings.field].unique = settings.unique;
   schema.add(fields);
 

--- a/index.js
+++ b/index.js
@@ -65,6 +65,7 @@ exports.plugin = function (schema, options) {
     type: Number,
     require: true
   };
+  // if we assign .unique = false Mongoose will create a non-unique index
   if (settings.field !== '_id' && settings.unique)
     fields[settings.field].unique = settings.unique;
   schema.add(fields);

--- a/test/test.js
+++ b/test/test.js
@@ -217,11 +217,16 @@ describe('mongoose-auto-increment', function () {
       dept: String
     });
     userSchema.plugin(autoIncrement.plugin, { model: 'User', field: 'userId', unique: false });
-    connection.model('User', userSchema);
+    var User = connection.model('User', userSchema);
 
     // Assert
     userSchema.path('userId').options.should.not.have.property('unique');
 
+    return new User({ name: 'Charlie', dept: 'Support', userId: 10 }).save()
+      .then(() => User.collection.getIndexes())
+      .then((indexes) => {
+        Object.keys(indexes).should.eql(['_id_']);
+      });
   });
 
   describe('helper function', function () {

--- a/test/test.js
+++ b/test/test.js
@@ -209,6 +209,21 @@ describe('mongoose-auto-increment', function () {
 
   });
 
+  it('should not add a unique index if unique=false in options', function() {
+
+    // Arrange
+    var userSchema = new mongoose.Schema({
+      name: String,
+      dept: String
+    });
+    userSchema.plugin(autoIncrement.plugin, { model: 'User', field: 'userId', unique: false });
+    connection.model('User', userSchema);
+
+    // Assert
+    userSchema.path('userId').options.should.not.have.property('unique');
+
+  });
+
   describe('helper function', function () {
 
     it('nextCount should return the next count for the model and field (Test 5)', function (done) {


### PR DESCRIPTION
This plugin configures the field option `.unique = settings.unique`.
Even if we pass `false`, an index is still created.

We'll add several fields:
```
project {
 stores: {
   apple: { gameId ... },
   google: { gameId ... },
   xiaomi: { gameId ... },
 }
}
```
This would create 3 indexes on that collection. We don't use the indexes at the moment, so we thought it's prudent not to create unused indexes.
Projects that want an index can still explicitly create it via their Mongoose schema after setting `unique = false` for this helper.