### PR TITLE
Remove invalid parameters when creating index

### DIFF
--- a/index.js
+++ b/index.js
@@ -18,7 +18,7 @@ exports.initialize = function (connection) {
       });
 
       // Create a unique index using the "field" and "model" fields.
-      counterSchema.index({ field: 1, model: 1 }, { unique: true, required: true, index: -1 });
+      counterSchema.index({ field: 1, model: 1 }, { unique: true });
 
       // Create model using new schema.
       IdentityCounter = connection.model('IdentityCounter', counterSchema);


### PR DESCRIPTION
Remove two parameters: `required` and `index` from index parameters when creating unique index for the counters. 

The allowed parameters for mongo 3.4 are: https://docs.mongodb.com/v3.4/reference/method/db.collection.createIndex/#options-for-all-index-types

And for mongo 2.6: https://docs.mongodb.com/v2.6/reference/method/db.collection.ensureIndex/#options-for-all-index-types
Reson for this is that when you try to use this library with mongo 3.4 the index creation results in an error from mongo:

```
(node:21) UnhandledPromiseRejectionWarning: Unhandled promise rejection (rejection id: 1): MongoError: The field 'required' is not valid for an index specification. Specification: { ns: "adsselfserve-dev.identitycounters", key: { field: 1, model: 1 }, name: "field_1_model_1", unique: true, required: true, index: -1, background: true }
```